### PR TITLE
Fix zero limit bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
+/build/
 *.tar.gz
+
+#IntelliJ
 .idea
 *.iml
-/build/
+
+#VSCode
+.vscode

--- a/api/search.go
+++ b/api/search.go
@@ -60,11 +60,27 @@ func SearchHandlerFunc(queryBuilder QueryBuilder, elasticSearchClient ElasticSea
 			http.Error(w, "Invalid limit parameter", http.StatusBadRequest)
 			return
 		}
+		if limit < 0 {
+			log.Event(ctx, "numeric search parameter provided with negative value", log.Data{
+				"param": "limit",
+				"value": limitParam,
+			}, log.WARN)
+			http.Error(w, "Invalid limit parameter", http.StatusBadRequest)
+			return
+		}
 
 		offsetParam := paramGet(params, "offset", "0")
 		offset, err := strconv.Atoi(offsetParam)
 		if err != nil {
 			log.Event(ctx, "numeric search parameter provided with non numeric characters", log.Data{
+				"param": "from",
+				"value": offsetParam,
+			}, log.WARN)
+			http.Error(w, "Invalid offset parameter", http.StatusBadRequest)
+			return
+		}
+		if offset < 0 {
+			log.Event(ctx, "numeric search parameter provided with negative value", log.Data{
 				"param": "from",
 				"value": offsetParam,
 			}, log.WARN)

--- a/api/search_test.go
+++ b/api/search_test.go
@@ -35,6 +35,24 @@ func TestSearchHandlerFunc(t *testing.T) {
 		So(esMock.MultiSearchCalls(), ShouldHaveLength, 0)
 	})
 
+	Convey("Should return BadRequest for negative limit parameter", t, func() {
+		qbMock := newQueryBuilderMock(nil, nil)
+		esMock := newElasticSearcherMock(nil, nil)
+		trMock := newResponseTransformerMock(nil, nil)
+
+		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
+
+		req := httptest.NewRequest("GET", "http://localhost:8080/search?limit=-1", nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		So(resp.Code, ShouldEqual, http.StatusBadRequest)
+		So(resp.Body.String(), ShouldContainSubstring, "Invalid limit parameter")
+		So(qbMock.BuildSearchQueryCalls(), ShouldHaveLength, 0)
+		So(esMock.MultiSearchCalls(), ShouldHaveLength, 0)
+	})
+
 	Convey("Should return BadRequest for invalid offset parameter", t, func() {
 		qbMock := newQueryBuilderMock(nil, nil)
 		esMock := newElasticSearcherMock(nil, nil)
@@ -43,6 +61,24 @@ func TestSearchHandlerFunc(t *testing.T) {
 		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
 
 		req := httptest.NewRequest("GET", "http://localhost:8080/search?offset=b", nil)
+		resp := httptest.NewRecorder()
+
+		searchHandler.ServeHTTP(resp, req)
+
+		So(resp.Code, ShouldEqual, http.StatusBadRequest)
+		So(resp.Body.String(), ShouldContainSubstring, "Invalid offset parameter")
+		So(qbMock.BuildSearchQueryCalls(), ShouldHaveLength, 0)
+		So(esMock.MultiSearchCalls(), ShouldHaveLength, 0)
+	})
+
+	Convey("Should return BadRequest for negative offset parameter", t, func() {
+		qbMock := newQueryBuilderMock(nil, nil)
+		esMock := newElasticSearcherMock(nil, nil)
+		trMock := newResponseTransformerMock(nil, nil)
+
+		searchHandler := SearchHandlerFunc(qbMock, esMock, trMock)
+
+		req := httptest.NewRequest("GET", "http://localhost:8080/search?offset=-1", nil)
 		resp := httptest.NewRecorder()
 
 		searchHandler.ServeHTTP(resp, req)

--- a/cmd/dp-search-query/main.go
+++ b/cmd/dp-search-query/main.go
@@ -20,7 +20,7 @@ func main() {
 
 	cfg, err := config.Get()
 	if err != nil {
-		log.Event(nil, "error retreiving config", log.Error(err), log.FATAL)
+		log.Event(nil, "error retrieving config", log.Error(err), log.FATAL)
 		os.Exit(1)
 	}
 

--- a/templates/search/contentQuery.tmpl
+++ b/templates/search/contentQuery.tmpl
@@ -3,8 +3,7 @@
  {{- if .From -}}
  	"from" : {{- .From}},
  {{- end}}
- {{if .Size}}
- 	 "size" : {{.Size}},{{end}}
+ "size" : {{.Size}},
  "query" : {
      "bool" : {
        "must" : {


### PR DESCRIPTION
### What

Fix the issue where a limit of 0 actually returned the elastic search default number of results instead of just the counts.

Also fixes the issue where negative values for limit or offset weren't being rejected.

(Also updated gitignore and an errant typo while I was at it).

### How to review

Ensure the API returns zero results when a limit of 0 is supplied
Ensure that negative values for limit and offset are rejected.

### Who can review

Anyone but me.