### PR TITLE
change sort query name in swagger

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -37,7 +37,7 @@ paths:
           collectionFormat: csv
           required: false
         - in: query
-          name: sort_order
+          name: sort
           description: "The order to return the results."
           type: string
           enum: [relevance, release_date, title]


### PR DESCRIPTION
### What

**Describe what you have changed and why.**
- Change sort query name from `sort_order` to `sort` as the code uses `sort`

### How to review

**Describe the steps required to test the changes.**
- Check if it is correct

### Who can review

**Describe who worked on the changes, so that other people can review.**
Anyone - Justin made the changes